### PR TITLE
Avoid loosing stderr output

### DIFF
--- a/rsh.c
+++ b/rsh.c
@@ -396,8 +396,6 @@ done:
 				FD_SET(2, &outfdset);
 				FD_CLR(esock, &infdset);
 			}
-		} else {
-			len[2] = 0;
 		}
 
 		if(FD_ISSET(2, &outfd)) {


### PR DESCRIPTION
Revert a change from commit f042863 that will cause all stderr output from the remote side to get lost.